### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Try these URLs:
 	```
 
 3.	The server also has a lightweight implementation of the API v4 threatMatches endpoint.  
-To use the local proxy server to check a URL, send a POST request to `127.0.0.1:8080/v1beta1/urs:search` with the following JSON body:
+To use the local proxy server to check a URL, send a POST request to `127.0.0.1:8080/v1beta1/uris:search` with the following JSON body:
 
 	```json
 	{


### PR DESCRIPTION
This should be `v1beta1/uris:search`:
https://github.com/google/webrisk/blob/1694bb28f3a51a3440ebbdb57e1d37e5c3d3d2b7/cmd/wrserver/main.go#L212